### PR TITLE
add 'revision' attribute to git_commit

### DIFF
--- a/docs/data-sources/commit.md
+++ b/docs/data-sources/commit.md
@@ -13,9 +13,34 @@ Fetches information about a single commit.
 ## Example Usage
 
 ```terraform
-data "git_commit" "commit" {
+# get commit by full sha1
+data "git_commit" "full_sha1" {
   directory = "/path/to/git/repository"
-  sha1      = "afe4"
+  revision  = "dae86e1950b1277e545cee180551750029cfe735"
+}
+
+# get commit by short sha1
+data "git_commit" "short_sha1" {
+  directory = "/path/to/git/repository"
+  revision  = "dae86e"
+}
+
+# get commit by refname
+data "git_commit" "refname" {
+  directory = "/path/to/git/repository"
+  revision  = "main"
+}
+
+# get commit by head shortcut
+data "git_commit" "head_shortcut" {
+  directory = "/path/to/git/repository"
+  revision  = "@"
+}
+
+# get commit by parent
+data "git_commit" "head_parent" {
+  directory = "/path/to/git/repository"
+  revision  = "HEAD~1"
 }
 ```
 
@@ -25,14 +50,15 @@ data "git_commit" "commit" {
 ### Required
 
 - `directory` (String) The path to the local Git repository.
-- `sha1` (String) The SHA1 checksum of the commit. Can be the entire SHA1 hash or at least the first 4 letters of the hash.
+- `revision` (String) The [revision](https://www.git-scm.com/docs/gitrevisions) of the commit to fetch. Note that `go-git` does not [support](https://pkg.go.dev/github.com/go-git/go-git/v5#Repository.ResolveRevision) every revision type at the moment.
 
 ### Read-Only
 
 - `author` (Attributes) The original author of the commit. (see [below for nested schema](#nestedatt--author))
 - `committer` (Attributes) The person performing the commit. (see [below for nested schema](#nestedatt--committer))
-- `id` (String) The same value as the `sha1` attribute.
+- `id` (String) The same value as the `revision` attribute.
 - `message` (String) The message of the commit.
+- `sha1` (String) The SHA1 hash of the resolved revision.
 - `signature` (String) The signature of the commit.
 - `tree_sha1` (String) The SHA1 checksum of the root tree of the commit.
 

--- a/examples/data-sources/git_commit/data-source.tf
+++ b/examples/data-sources/git_commit/data-source.tf
@@ -1,4 +1,29 @@
-data "git_commit" "commit" {
+# get commit by full sha1
+data "git_commit" "full_sha1" {
   directory = "/path/to/git/repository"
-  sha1      = "afe4"
+  revision  = "dae86e1950b1277e545cee180551750029cfe735"
+}
+
+# get commit by short sha1
+data "git_commit" "short_sha1" {
+  directory = "/path/to/git/repository"
+  revision  = "dae86e"
+}
+
+# get commit by refname
+data "git_commit" "refname" {
+  directory = "/path/to/git/repository"
+  revision  = "main"
+}
+
+# get commit by head shortcut
+data "git_commit" "head_shortcut" {
+  directory = "/path/to/git/repository"
+  revision  = "@"
+}
+
+# get commit by parent
+data "git_commit" "head_parent" {
+  directory = "/path/to/git/repository"
+  revision  = "HEAD~1"
 }

--- a/internal/provider/data_source_git_commit_test.go
+++ b/internal/provider/data_source_git_commit_test.go
@@ -31,12 +31,95 @@ func TestDataSourceGitCommit(t *testing.T) {
 				Config: fmt.Sprintf(`
 					data "git_commit" "test" {
 						directory = "%s"
-						sha1      = "%s"
+						revision  = "%s"
 					}
 				`, directory, commit.String()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.git_commit.test", "directory", directory),
 					resource.TestCheckResourceAttr("data.git_commit.test", "id", commit.String()),
+					resource.TestCheckResourceAttr("data.git_commit.test", "revision", commit.String()),
+					resource.TestCheckResourceAttr("data.git_commit.test", "sha1", commit.String()),
+					resource.TestCheckResourceAttr("data.git_commit.test", "signature", ""),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "message", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "tree_sha1", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "author.name", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "author.email", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "author.timestamp", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "committer.name", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "committer.email", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "committer.timestamp", testCheckMinLength(1)),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSourceGitCommit_WithHead(t *testing.T) {
+	t.Parallel()
+	directory, repository := testRepository(t)
+	defer os.RemoveAll(directory)
+	testConfig(t, repository)
+	worktree := testWorktree(t, repository)
+	fileName := "some-file"
+	testWriteFile(t, worktree, fileName)
+	testGitAdd(t, worktree, fileName)
+	commit := testGitCommit(t, worktree)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "git_commit" "test" {
+						directory = "%s"
+						revision  = "HEAD"
+					}
+				`, directory),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.git_commit.test", "directory", directory),
+					resource.TestCheckResourceAttr("data.git_commit.test", "id", "HEAD"),
+					resource.TestCheckResourceAttr("data.git_commit.test", "revision", "HEAD"),
+					resource.TestCheckResourceAttr("data.git_commit.test", "sha1", commit.String()),
+					resource.TestCheckResourceAttr("data.git_commit.test", "signature", ""),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "message", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "tree_sha1", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "author.name", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "author.email", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "author.timestamp", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "committer.name", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "committer.email", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("data.git_commit.test", "committer.timestamp", testCheckMinLength(1)),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSourceGitCommit_WithBranch(t *testing.T) {
+	t.Parallel()
+	directory, repository := testRepository(t)
+	defer os.RemoveAll(directory)
+	testConfig(t, repository)
+	worktree := testWorktree(t, repository)
+	fileName := "some-file"
+	testWriteFile(t, worktree, fileName)
+	testGitAdd(t, worktree, fileName)
+	commit := testGitCommit(t, worktree)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					data "git_commit" "test" {
+						directory = "%s"
+						revision  = "master"
+					}
+				`, directory),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.git_commit.test", "directory", directory),
+					resource.TestCheckResourceAttr("data.git_commit.test", "id", "master"),
+					resource.TestCheckResourceAttr("data.git_commit.test", "revision", "master"),
 					resource.TestCheckResourceAttr("data.git_commit.test", "sha1", commit.String()),
 					resource.TestCheckResourceAttr("data.git_commit.test", "signature", ""),
 					resource.TestCheckResourceAttrWith("data.git_commit.test", "message", testCheckMinLength(1)),
@@ -73,12 +156,13 @@ func TestDataSourceGitCommit_WithSignature(t *testing.T) {
 				Config: fmt.Sprintf(`
 					data "git_commit" "test" {
 						directory = "%s"
-						sha1      = "%s"
+						revision  = "%s"
 					}
 				`, directory, commit.String()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.git_commit.test", "directory", directory),
 					resource.TestCheckResourceAttr("data.git_commit.test", "id", commit.String()),
+					resource.TestCheckResourceAttr("data.git_commit.test", "revision", commit.String()),
 					resource.TestCheckResourceAttr("data.git_commit.test", "sha1", commit.String()),
 					resource.TestCheckResourceAttr("data.git_commit.test", "signature", ""),
 					resource.TestCheckResourceAttrWith("data.git_commit.test", "message", testCheckMinLength(1)),

--- a/tests/data_source_git_comit.tf
+++ b/tests/data_source_git_comit.tf
@@ -3,7 +3,7 @@
 
 data "git_commit" "current_head" {
   directory = data.git_repository.repository.directory
-  sha1      = data.git_repository.repository.sha1
+  revision  = "HEAD"
 }
 
 output "data_source_git_commit_current_head" {


### PR DESCRIPTION
This is a **breaking change** in order to support different ways to specify a single commit, e.g. by using 'HEAD'. The old 'sha1' is now read-only and populated by this provider after the given revision was resolved.

In order to migrate to the new version simply change 'sha1' to 'revision' in the declaration of your data source. The 'sha1' output stays the same, therefore no change is required in dependent resources.

Relates to #28