### PR TITLE
extract modified files in git_commit data source

### DIFF
--- a/docs/data-sources/commit.md
+++ b/docs/data-sources/commit.md
@@ -56,6 +56,7 @@ data "git_commit" "head_parent" {
 
 - `author` (Attributes) The original author of the commit. (see [below for nested schema](#nestedatt--author))
 - `committer` (Attributes) The person performing the commit. (see [below for nested schema](#nestedatt--committer))
+- `files` (List of String) The files updated by the commit.
 - `id` (String) The same value as the `revision` attribute.
 - `message` (String) The message of the commit.
 - `sha1` (String) The SHA1 hash of the resolved revision.

--- a/internal/provider/data_source_git_commit.go
+++ b/internal/provider/data_source_git_commit.go
@@ -33,6 +33,7 @@ type dataSourceGitCommitSchema struct {
 	Message   types.String `tfsdk:"message"`
 	Signature types.String `tfsdk:"signature"`
 	TreeSHA1  types.String `tfsdk:"tree_sha1"`
+	Files     types.List   `tfsdk:"files"`
 }
 
 func (r *dataSourceGitCommitType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
@@ -122,6 +123,13 @@ func (r *dataSourceGitCommitType) GetSchema(_ context.Context) (tfsdk.Schema, di
 				Type:        types.StringType,
 				Computed:    true,
 			},
+			"files": {
+				Description: "The files updated by the commit.",
+				Type: types.ListType{
+					ElemType: types.StringType,
+				},
+				Computed: true,
+			},
 		},
 	}, nil
 }
@@ -179,6 +187,7 @@ func (r *dataSourceGitCommit) Read(ctx context.Context, req datasource.ReadReque
 	state.TreeSHA1 = types.String{Value: commit.TreeHash.String()}
 	state.Author = signatureToObject(&commit.Author)
 	state.Committer = signatureToObject(&commit.Committer)
+	state.Files = stringsToList(extractModifiedFiles(commit))
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/git_commit.go
+++ b/internal/provider/git_commit.go
@@ -1,0 +1,51 @@
+/*
+ * SPDX-FileCopyrightText: The terraform-provider-git Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package provider
+
+import (
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func signatureToObject(signature *object.Signature) types.Object {
+	data := make(map[string]attr.Value)
+
+	if signature != nil {
+		data["name"] = types.String{Value: signature.Name}
+		data["email"] = types.String{Value: signature.Email}
+		data["timestamp"] = types.String{Value: signature.When.String()}
+	} else {
+		data["name"] = types.String{Null: true}
+		data["email"] = types.String{Null: true}
+		data["timestamp"] = types.String{Null: true}
+	}
+
+	return types.Object{
+		AttrTypes: map[string]attr.Type{
+			"name":      types.StringType,
+			"email":     types.StringType,
+			"timestamp": types.StringType,
+		},
+		Attrs: data,
+	}
+}
+
+func extractModifiedFiles(commit *object.Commit) []string {
+	fileNames := make([]string, 0)
+	files, err := commit.Files()
+	if err != nil {
+		return fileNames
+	}
+	err = files.ForEach(func(file *object.File) error {
+		fileNames = append(fileNames, file.Name)
+		return nil
+	})
+	if err != nil {
+		return fileNames
+	}
+	return fileNames
+}

--- a/internal/provider/terraform.go
+++ b/internal/provider/terraform.go
@@ -7,7 +7,6 @@ package provider
 
 import (
 	"context"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -29,28 +28,5 @@ func stringsToList(strings []string) types.List {
 	return types.List{
 		Elems:    values,
 		ElemType: types.StringType,
-	}
-}
-
-func signatureToObject(signature *object.Signature) types.Object {
-	data := make(map[string]attr.Value)
-
-	if signature != nil {
-		data["name"] = types.String{Value: signature.Name}
-		data["email"] = types.String{Value: signature.Email}
-		data["timestamp"] = types.String{Value: signature.When.String()}
-	} else {
-		data["name"] = types.String{Null: true}
-		data["email"] = types.String{Null: true}
-		data["timestamp"] = types.String{Null: true}
-	}
-
-	return types.Object{
-		AttrTypes: map[string]attr.Type{
-			"name":      types.StringType,
-			"email":     types.StringType,
-			"timestamp": types.StringType,
-		},
-		Attrs: data,
 	}
 }


### PR DESCRIPTION
This adds a new `files` attribute which contains the list of files that were modified by a commit.