### PR TITLE
add 'revision' attribute to 'git_tag"

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -83,7 +83,7 @@ jobs:
           terraform_wrapper: false
       - id: tests
         name: Run Tests
-        run: go test -v -cover -parallel=4 -timeout=120s ./internal/provider/
+        run: go test -v -cover -parallel=4 -timeout=240s ./internal/provider/
         env:
           TF_ACC: "1"
   acceptance:

--- a/docs/resources/tag.md
+++ b/docs/resources/tag.md
@@ -27,7 +27,19 @@ resource "git_tag" "annotated_tag" {
 resource "git_tag" "specific_commit" {
   directory = "/path/to/git/repository"
   name      = "v1.2.3"
-  sha1      = "b1af8d13f5131c9b4de9ddd06e311c2e79fdb285"
+  revision  = "b1af8d13f5131c9b4de9ddd06e311c2e79fdb285"
+}
+
+resource "git_tag" "head" {
+  directory = "/path/to/git/repository"
+  name      = "v1.2.3"
+  revision  = "HEAD"
+}
+
+resource "git_tag" "branch" {
+  directory = "/path/to/git/repository"
+  name      = "v1.2.3"
+  revision  = "main"
 }
 ```
 
@@ -42,11 +54,12 @@ resource "git_tag" "specific_commit" {
 ### Optional
 
 - `message` (String) The tag message to use. Note that by specifying a message, an annotated tag will be created.
-- `sha1` (String) The SHA1 checksum of the commit to tag. If none is specified, `HEAD` will be tagged.
+- `revision` (String) The [revision](https://www.git-scm.com/docs/gitrevisions) of the commit to tag. Can be any value that `go-git` [supports](https://pkg.go.dev/github.com/go-git/go-git/v5#Repository.ResolveRevision). If none is specified, `HEAD` will be tagged.
 
 ### Read-Only
 
 - `id` (String) The import ID to import this resource which has the form `'directory|name'`
+- `sha1` (String) The SHA1 hash of the resolved revision.
 
 ## Import
 
@@ -54,7 +67,8 @@ Import is supported using the following syntax:
 
 ```shell
 # git_tag resources can be imported by specifying the directory of the
-# Git repository and the name of the tag to import. Both values are
-# separated by a single '|'.
-terraform import git_tag.tag 'path/to/your/git/repository|name-of-your-tag'
+# Git repository, the name of the tag to import, and the revision. All
+# values are separated by a single '|'. The revision is optional and
+# will default to 'HEAD' if not specified.
+terraform import git_tag.tag 'path/to/your/git/repository|name-of-your-tag|revision'
 ```

--- a/examples/resources/git_tag/import.sh
+++ b/examples/resources/git_tag/import.sh
@@ -1,4 +1,5 @@
 # git_tag resources can be imported by specifying the directory of the
-# Git repository and the name of the tag to import. Both values are
-# separated by a single '|'.
-terraform import git_tag.tag 'path/to/your/git/repository|name-of-your-tag'
+# Git repository, the name of the tag to import, and the revision. All
+# values are separated by a single '|'. The revision is optional and
+# will default to 'HEAD' if not specified.
+terraform import git_tag.tag 'path/to/your/git/repository|name-of-your-tag|revision'

--- a/examples/resources/git_tag/resource.tf
+++ b/examples/resources/git_tag/resource.tf
@@ -12,5 +12,17 @@ resource "git_tag" "annotated_tag" {
 resource "git_tag" "specific_commit" {
   directory = "/path/to/git/repository"
   name      = "v1.2.3"
-  sha1      = "b1af8d13f5131c9b4de9ddd06e311c2e79fdb285"
+  revision  = "b1af8d13f5131c9b4de9ddd06e311c2e79fdb285"
+}
+
+resource "git_tag" "head" {
+  directory = "/path/to/git/repository"
+  name      = "v1.2.3"
+  revision  = "HEAD"
+}
+
+resource "git_tag" "branch" {
+  directory = "/path/to/git/repository"
+  name      = "v1.2.3"
+  revision  = "main"
 }

--- a/internal/provider/data_source_git_commit.go
+++ b/internal/provider/data_source_git_commit.go
@@ -7,7 +7,6 @@ package provider
 
 import (
 	"context"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -159,12 +158,8 @@ func (r *dataSourceGitCommit) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	hash, err := repository.ResolveRevision(plumbing.Revision(revision))
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Cannot resolve revision",
-			"Could not resolve revision ["+revision+"] because of: "+err.Error(),
-		)
+	hash := resolveRevision(ctx, repository, revision, &resp.Diagnostics)
+	if hash == nil {
 		return
 	}
 

--- a/internal/provider/git_log.go
+++ b/internal/provider/git_log.go
@@ -8,7 +8,6 @@ package provider
 import (
 	"context"
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"path"
@@ -24,15 +23,11 @@ func createLogOptions(ctx context.Context, repository *git.Repository, inputs *d
 	})
 
 	if !inputs.From.IsNull() && !inputs.From.IsUnknown() {
-		revision, err := repository.ResolveRevision(plumbing.Revision(inputs.From.Value))
-		if err != nil {
-			diag.AddError(
-				"Cannot resolve revision",
-				"Could revision ["+inputs.From.Value+"] because of: "+err.Error(),
-			)
+		hash := resolveRevision(ctx, repository, inputs.From.Value, diag)
+		if hash == nil {
 			return nil
 		}
-		logOptions.From = *revision
+		logOptions.From = *hash
 		tflog.Trace(ctx, "using 'From'", map[string]interface{}{
 			"from": logOptions.From,
 		})

--- a/internal/provider/git_repository.go
+++ b/internal/provider/git_repository.go
@@ -8,6 +8,7 @@ package provider
 import (
 	"context"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -25,4 +26,20 @@ func openRepository(ctx context.Context, directory string, diag *diag.Diagnostic
 		"directory": directory,
 	})
 	return repository
+}
+
+func resolveRevision(ctx context.Context, repository *git.Repository, revision string, diag *diag.Diagnostics) *plumbing.Hash {
+	hash, err := repository.ResolveRevision(plumbing.Revision(revision))
+	if err != nil {
+		diag.AddError(
+			"Cannot resolve revision",
+			"Could not resolve revision ["+revision+"] because of: "+err.Error(),
+		)
+		return nil
+	}
+	tflog.Trace(ctx, "resolved revision", map[string]interface{}{
+		"revision": revision,
+		"hash":     hash.String(),
+	})
+	return hash
 }

--- a/internal/provider/git_tag.go
+++ b/internal/provider/git_tag.go
@@ -14,18 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-func createTagReference(repository *git.Repository, inputs resourceGitTagSchema) (*plumbing.Reference, error) {
-	if inputs.SHA1.IsNull() || inputs.SHA1.IsUnknown() {
-		head, err := repository.Head()
-		if err != nil {
-			return nil, err
-		}
-		return head, nil
-	}
-
-	return plumbing.NewHashReference("tag", plumbing.NewHash(inputs.SHA1.Value)), nil
-}
-
 func createTagOptions(inputs resourceGitTagSchema) *git.CreateTagOptions {
 	if inputs.Message.IsNull() || inputs.Message.IsUnknown() {
 		return nil

--- a/internal/provider/resource_git_tag_test.go
+++ b/internal/provider/resource_git_tag_test.go
@@ -36,6 +36,8 @@ func TestResourceGitTag(t *testing.T) {
 					resource.TestCheckResourceAttr("git_tag.test", "directory", directory),
 					resource.TestCheckResourceAttr("git_tag.test", "id", fmt.Sprintf("%s|%s", directory, name)),
 					resource.TestCheckResourceAttr("git_tag.test", "name", name),
+					resource.TestCheckResourceAttrWith("git_tag.test", "revision", testCheckMinLength(1)),
+					resource.TestCheckResourceAttrWith("git_tag.test", "sha1", testCheckMinLength(1)),
 				),
 			},
 		},
@@ -74,7 +76,7 @@ func TestResourceGitTag_Annotated(t *testing.T) {
 	})
 }
 
-func TestResourceGitTag_Commitish(t *testing.T) {
+func TestResourceGitTag_Revision_Hash(t *testing.T) {
 	t.Parallel()
 	directory, repository := testRepository(t)
 	defer os.RemoveAll(directory)
@@ -95,20 +97,94 @@ func TestResourceGitTag_Commitish(t *testing.T) {
 					resource "git_tag" "test" {
 						directory = "%s"
 						name      = "%s"
-						sha1      = "%s"
+						revision  = "%s"
 					}
 				`, directory, name, head.Hash().String()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("git_tag.test", "directory", directory),
 					resource.TestCheckResourceAttr("git_tag.test", "id", fmt.Sprintf("%s|%s", directory, name)),
 					resource.TestCheckResourceAttr("git_tag.test", "name", name),
+					resource.TestCheckResourceAttr("git_tag.test", "revision", head.Hash().String()),
+					resource.TestCheckResourceAttr("git_tag.test", "sha1", head.Hash().String()),
 				),
 			},
 		},
 	})
 }
 
-func TestResourceGitTag_InvalidRepository(t *testing.T) {
+func TestResourceGitTag_Revision_Head(t *testing.T) {
+	t.Parallel()
+	directory, repository := testRepository(t)
+	defer os.RemoveAll(directory)
+	testConfig(t, repository)
+	worktree := testWorktree(t, repository)
+	testAddAndCommitNewFile(t, worktree, "some-file")
+	head, err := repository.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := "some-name"
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "git_tag" "test" {
+						directory = "%s"
+						name      = "%s"
+						revision  = "HEAD"
+					}
+				`, directory, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("git_tag.test", "directory", directory),
+					resource.TestCheckResourceAttr("git_tag.test", "id", fmt.Sprintf("%s|%s", directory, name)),
+					resource.TestCheckResourceAttr("git_tag.test", "name", name),
+					resource.TestCheckResourceAttr("git_tag.test", "revision", "HEAD"),
+					resource.TestCheckResourceAttr("git_tag.test", "sha1", head.Hash().String()),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceGitTag_Revision_Master(t *testing.T) {
+	t.Parallel()
+	directory, repository := testRepository(t)
+	defer os.RemoveAll(directory)
+	testConfig(t, repository)
+	worktree := testWorktree(t, repository)
+	testAddAndCommitNewFile(t, worktree, "some-file")
+	head, err := repository.Head()
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := "some-name"
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "git_tag" "test" {
+						directory = "%s"
+						name      = "%s"
+						revision  = "master"
+					}
+				`, directory, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("git_tag.test", "directory", directory),
+					resource.TestCheckResourceAttr("git_tag.test", "id", fmt.Sprintf("%s|%s", directory, name)),
+					resource.TestCheckResourceAttr("git_tag.test", "name", name),
+					resource.TestCheckResourceAttr("git_tag.test", "revision", "master"),
+					resource.TestCheckResourceAttr("git_tag.test", "sha1", head.Hash().String()),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceGitTag_Directory_Invalid(t *testing.T) {
 	t.Parallel()
 	name := "some-name"
 
@@ -128,7 +204,7 @@ func TestResourceGitTag_InvalidRepository(t *testing.T) {
 	})
 }
 
-func TestResourceGitTag_MissingRepository(t *testing.T) {
+func TestResourceGitTag_Directory_Missing(t *testing.T) {
 	t.Parallel()
 	name := "some-name"
 
@@ -147,7 +223,7 @@ func TestResourceGitTag_MissingRepository(t *testing.T) {
 	})
 }
 
-func TestResourceGitTag_MissingName(t *testing.T) {
+func TestResourceGitTag_Name_Missing(t *testing.T) {
 	t.Parallel()
 	directory, _ := testRepository(t)
 	defer os.RemoveAll(directory)
@@ -190,6 +266,7 @@ func TestResourceGitTag_Import(t *testing.T) {
 					resource.TestCheckResourceAttr("git_tag.test", "directory", directory),
 					resource.TestCheckResourceAttr("git_tag.test", "id", fmt.Sprintf("%s|%s", directory, name)),
 					resource.TestCheckResourceAttr("git_tag.test", "name", name),
+					resource.TestCheckResourceAttr("git_tag.test", "revision", "HEAD"),
 				),
 			},
 			{
@@ -202,7 +279,45 @@ func TestResourceGitTag_Import(t *testing.T) {
 	})
 }
 
-func TestResourceGitTag_Update_Name(t *testing.T) {
+func TestResourceGitTag_Import_Symbolic(t *testing.T) {
+	t.Parallel()
+	directory, repository := testRepository(t)
+	defer os.RemoveAll(directory)
+	testConfig(t, repository)
+	worktree := testWorktree(t, repository)
+	testAddAndCommitNewFile(t, worktree, "some-file")
+	name := "some-name"
+	revision := "master"
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "git_tag" "test" {
+						directory = "%s"
+						name      = "%s"
+						revision  = "%s" 
+					}
+				`, directory, name, revision),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("git_tag.test", "directory", directory),
+					resource.TestCheckResourceAttr("git_tag.test", "id", fmt.Sprintf("%s|%s", directory, name)),
+					resource.TestCheckResourceAttr("git_tag.test", "name", name),
+					resource.TestCheckResourceAttr("git_tag.test", "revision", revision),
+				),
+			},
+			{
+				ResourceName:      "git_tag.test",
+				ImportState:       true,
+				ImportStateId:     fmt.Sprintf("%s|%s|%s", directory, name, revision),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestResourceGitTag_Name_Update(t *testing.T) {
 	t.Parallel()
 	directory, repository := testRepository(t)
 	defer os.RemoveAll(directory)
@@ -245,7 +360,7 @@ func TestResourceGitTag_Update_Name(t *testing.T) {
 	})
 }
 
-func TestResourceGitTag_Update_Directory(t *testing.T) {
+func TestResourceGitTag_Directory_Update(t *testing.T) {
 	t.Parallel()
 	directory, repository := testRepository(t)
 	defer os.RemoveAll(directory)


### PR DESCRIPTION
add `revision` attribute to `git_tag`

This is a breaking change in order to allow arbitrary revisions as inputs to `git_tag`. The `sha1` attribute is still computed as an output value.