### PR TITLE
fix git_add resource

### DIFF
--- a/docs/resources/add.md
+++ b/docs/resources/add.md
@@ -3,38 +3,42 @@
 page_title: "git_add Resource - terraform-provider-git"
 subcategory: ""
 description: |-
-  Add file contents to the index using git add.
+  Add file contents to the index similar to git add.
 ---
 
 # git_add (Resource)
 
-Add file contents to the index using `git add`.
+Add file contents to the index similar to `git add`.
 
 ## Example Usage
 
 ```terraform
 # add single file
-resource "git_add" "file" {
+resource "git_add" "single_file" {
   directory  = "/path/to/git/repository"
-  exact_path = "path/to/file/in/repository"
+  add_paths  = ["path/to/file/in/repository"]
 }
 
 # add all files in directory and its subdirectory recursively
-resource "git_add" "directory" {
+resource "git_add" "single_directory" {
   directory  = "/path/to/git/repository"
-  exact_path = "path/to/directory/in/repository"
+  add_paths  = ["path/to/directory/in/repository"]
 }
 
 # add files matching pattern
-resource "git_add" "glob" {
+resource "git_add" "glob_pattern" {
   directory = "/path/to/git/repository"
-  glob_path = "path/*/in/repo*"
+  add_paths = ["path/*/in/repo*"]
 }
 
-# add all modified files
-resource "git_add" "all" {
+# mix exact paths and glob patterns
+resource "git_add" "glob_pattern" {
   directory = "/path/to/git/repository"
-  all       = true
+  add_paths = [
+    "path/*/in/repo*",
+    "another/path/to/file/here",
+    "this/could/be/a/directory",
+  ]
 }
 ```
 
@@ -47,12 +51,10 @@ resource "git_add" "all" {
 
 ### Optional
 
-- `all` (Boolean) Update the index not only where the working tree has a file matching `exact_path` or `glob_path` but also where the index already has an entry. This adds, modifies, and removes index entries to match the working tree. If no paths are given, all files in the entire working tree are updated. Defaults to `true`.
-- `exact_path` (String) The exact filepath to the file or directory to be added. Conflicts with `glob_path`.
-- `glob_path` (String) The glob pattern of files or directories to be added. Conflicts with `exact_path`.
+- `add_paths` (List of String) The paths to add to the Git index. Values can be exact paths or glob patterns.
 
 ### Read-Only
 
-- `id` (String) The same value as the `directory` attribute.
+- `id` (Number) The timestamp of the last addition in Unix nanoseconds.
 
 

--- a/examples/resources/git_add/resource.tf
+++ b/examples/resources/git_add/resource.tf
@@ -1,23 +1,27 @@
 # add single file
-resource "git_add" "file" {
+resource "git_add" "single_file" {
   directory  = "/path/to/git/repository"
-  exact_path = "path/to/file/in/repository"
+  add_paths  = ["path/to/file/in/repository"]
 }
 
 # add all files in directory and its subdirectory recursively
-resource "git_add" "directory" {
+resource "git_add" "single_directory" {
   directory  = "/path/to/git/repository"
-  exact_path = "path/to/directory/in/repository"
+  add_paths  = ["path/to/directory/in/repository"]
 }
 
 # add files matching pattern
-resource "git_add" "glob" {
+resource "git_add" "glob_pattern" {
   directory = "/path/to/git/repository"
-  glob_path = "path/*/in/repo*"
+  add_paths = ["path/*/in/repo*"]
 }
 
-# add all modified files
-resource "git_add" "all" {
+# mix exact paths and glob patterns
+resource "git_add" "glob_pattern" {
   directory = "/path/to/git/repository"
-  all       = true
+  add_paths = [
+    "path/*/in/repo*",
+    "another/path/to/file/here",
+    "this/could/be/a/directory",
+  ]
 }

--- a/internal/modifiers/default_value.go
+++ b/internal/modifiers/default_value.go
@@ -7,7 +7,6 @@ package modifiers
 
 import (
 	"context"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
@@ -22,7 +21,7 @@ type defaultValueAttributePlanModifier struct {
 	defaultValue attr.Value
 }
 
-func (d *defaultValueAttributePlanModifier) Description(ctx context.Context) string {
+func (d *defaultValueAttributePlanModifier) Description(_ context.Context) string {
 	return "If the config does not contain a value, a default will be set using defaultValue."
 }
 
@@ -33,9 +32,9 @@ func (d *defaultValueAttributePlanModifier) MarkdownDescription(ctx context.Cont
 // Modify checks that the value of the attribute in the configuration and assigns the default value if
 // the value in the config is null. This is a destructive operation in that it will overwrite any value
 // present in the plan.
-func (d *defaultValueAttributePlanModifier) Modify(ctx context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
-	// If the attribute configuration is not null, we are done here
+func (d *defaultValueAttributePlanModifier) Modify(_ context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
 	if !req.AttributeConfig.IsNull() {
+		// If the attribute configuration is not null, we are done here
 		return
 	}
 

--- a/internal/provider/resource_git_add_test.go
+++ b/internal/provider/resource_git_add_test.go
@@ -29,81 +29,20 @@ func TestResourceGitAdd(t *testing.T) {
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
 						directory  = "%s"
-					}
-				`, directory),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckNoResourceAttr("git_add.test", "exact_path"),
-					resource.TestCheckNoResourceAttr("git_add.test", "glob_path"),
-				),
-			},
-		},
-	})
-}
-
-func TestResourceGitAdd_All_Disabled(t *testing.T) {
-	t.Parallel()
-	directory, repository := testutils.CreateRepository(t)
-	defer os.RemoveAll(directory)
-	worktree := testutils.GetRepositoryWorktree(t, repository)
-	name := "some-file"
-	testutils.WriteFileInWorktree(t, worktree, name)
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutils.ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-					resource "git_add" "test" {
-						directory  = "%s"
-						all        = "false"
-					}
-				`, directory),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "false"),
-					resource.TestCheckNoResourceAttr("git_add.test", "exact_path"),
-					resource.TestCheckNoResourceAttr("git_add.test", "glob_path"),
-				),
-			},
-		},
-	})
-}
-
-func TestResourceGitAdd_ExactPath(t *testing.T) {
-	t.Parallel()
-	directory, repository := testutils.CreateRepository(t)
-	defer os.RemoveAll(directory)
-	worktree := testutils.GetRepositoryWorktree(t, repository)
-	name := "some-file"
-	testutils.WriteFileInWorktree(t, worktree, name)
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutils.ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-					resource "git_add" "test" {
-						directory  = "%s"
-						exact_path = "%s"
+						add_paths  = ["%s"]
 					}
 				`, directory, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckResourceAttr("git_add.test", "exact_path", name),
-					resource.TestCheckNoResourceAttr("git_add.test", "glob_path"),
+					resource.TestCheckResourceAttrWith("git_add.test", "id", testutils.CheckMinLength(1)),
+					resource.TestCheckResourceAttr("git_add.test", "add_paths.0", name),
 				),
 			},
 		},
 	})
 }
 
-func TestResourceGitAdd_GlobPath(t *testing.T) {
+func TestResourceGitAdd_AddPaths_Multiple(t *testing.T) {
 	t.Parallel()
 	directory, repository := testutils.CreateRepository(t)
 	defer os.RemoveAll(directory)
@@ -118,22 +57,21 @@ func TestResourceGitAdd_GlobPath(t *testing.T) {
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
 						directory  = "%s"
-						glob_path  = "some*"
+						add_paths  = ["%s", "other-file"]
 					}
-				`, directory),
+				`, directory, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckNoResourceAttr("git_add.test", "exact_path"),
-					resource.TestCheckResourceAttr("git_add.test", "glob_path", "some*"),
+					resource.TestCheckResourceAttrWith("git_add.test", "id", testutils.CheckMinLength(1)),
+					resource.TestCheckResourceAttr("git_add.test", "add_paths.0", name),
+					resource.TestCheckResourceAttr("git_add.test", "add_paths.1", "other-file"),
 				),
 			},
 		},
 	})
 }
 
-func TestResourceGitAdd_ExactPath_NonExistingFile(t *testing.T) {
+func TestResourceGitAdd_AddPaths_NonExistingFile(t *testing.T) {
 	t.Parallel()
 	directory, _ := testutils.CreateRepository(t)
 	defer os.RemoveAll(directory)
@@ -146,22 +84,20 @@ func TestResourceGitAdd_ExactPath_NonExistingFile(t *testing.T) {
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
 						directory  = "%s"
-						exact_path = "%s"
+						add_paths  = ["%s"]
 					}
 				`, directory, name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckResourceAttr("git_add.test", "exact_path", name),
-					resource.TestCheckNoResourceAttr("git_add.test", "glob_path"),
+					resource.TestCheckResourceAttrWith("git_add.test", "id", testutils.CheckMinLength(1)),
+					resource.TestCheckResourceAttr("git_add.test", "add_paths.0", name),
 				),
 			},
 		},
 	})
 }
 
-func TestResourceGitAdd_ExactPath_Directory(t *testing.T) {
+func TestResourceGitAdd_AddPaths_Directory(t *testing.T) {
 	t.Parallel()
 	directory, _ := testutils.CreateRepository(t)
 	defer os.RemoveAll(directory)
@@ -177,80 +113,14 @@ func TestResourceGitAdd_ExactPath_Directory(t *testing.T) {
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
 						directory  = "%s"
-						exact_path = "%s"
+						add_paths  = ["%s"]
 					}
 				`, directory, "nested-folder"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckResourceAttr("git_add.test", "exact_path", "nested-folder"),
-					resource.TestCheckNoResourceAttr("git_add.test", "glob_path"),
+					resource.TestCheckResourceAttrWith("git_add.test", "id", testutils.CheckMinLength(1)),
+					resource.TestCheckResourceAttr("git_add.test", "add_paths.0", "nested-folder"),
 				),
-			},
-		},
-	})
-}
-
-func TestResourceGitAdd_ExactPath_GlobPath(t *testing.T) {
-	t.Parallel()
-	directory, _ := testutils.CreateRepository(t)
-	defer os.RemoveAll(directory)
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutils.ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-					resource "git_add" "test" {
-						directory  = "%s"
-						exact_path = "some-file"
-						glob_path  = "some*"
-					}
-				`, directory),
-				ExpectError: regexp.MustCompile(`Invalid Attribute Combination`),
-			},
-		},
-	})
-}
-
-func TestResourceGitAdd_ExactPath_EmptyString(t *testing.T) {
-	t.Parallel()
-	directory, _ := testutils.CreateRepository(t)
-	defer os.RemoveAll(directory)
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutils.ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-					resource "git_add" "test" {
-						directory  = "%s"
-						exact_path = ""
-					}
-				`, directory),
-				ExpectError: regexp.MustCompile(`Invalid Attribute Value Length`),
-			},
-		},
-	})
-}
-
-func TestResourceGitAdd_GlobPath_EmptyString(t *testing.T) {
-	t.Parallel()
-	directory, _ := testutils.CreateRepository(t)
-	defer os.RemoveAll(directory)
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutils.ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-					resource "git_add" "test" {
-						directory  = "%s"
-						glob_path  = ""
-					}
-				`, directory),
-				ExpectError: regexp.MustCompile(`Invalid Attribute Value Length`),
 			},
 		},
 	})
@@ -269,7 +139,7 @@ func TestResourceGitAdd_BareRepository(t *testing.T) {
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
 						directory  = "%s"
-						exact_path = "%s"
+						add_paths  = ["%s"]
 					}
 				`, directory, name),
 				ExpectError: regexp.MustCompile(`Cannot add file to bare repository`),
@@ -289,7 +159,7 @@ func TestResourceGitAdd_Directory_Invalid(t *testing.T) {
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
 						directory  = "/some/random/path"
-						exact_path = "%s"
+						add_paths  = ["%s"]
 					}
 				`, name),
 				ExpectError: regexp.MustCompile(`Cannot open repository`),
@@ -308,7 +178,7 @@ func TestResourceGitAdd_Directory_Missing(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
-						exact_path = "%s"
+						add_paths = ["%s"]
 					}
 				`, name),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
@@ -317,7 +187,7 @@ func TestResourceGitAdd_Directory_Missing(t *testing.T) {
 	})
 }
 
-func TestResourceGitAdd_ExactPath_Update(t *testing.T) {
+func TestResourceGitAdd_AddPaths_Update(t *testing.T) {
 	t.Parallel()
 	directory, repository := testutils.CreateRepository(t)
 	defer os.RemoveAll(directory)
@@ -334,77 +204,26 @@ func TestResourceGitAdd_ExactPath_Update(t *testing.T) {
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
 						directory  = "%s"
-						exact_path = "%s"
+						add_paths  = ["%s"]
 					}
 				`, directory, name1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckResourceAttr("git_add.test", "exact_path", name1),
-					resource.TestCheckNoResourceAttr("git_add.test", "glob_path"),
+					resource.TestCheckResourceAttrWith("git_add.test", "id", testutils.CheckMinLength(1)),
+					resource.TestCheckResourceAttr("git_add.test", "add_paths.0", name1),
 				),
 			},
 			{
 				Config: fmt.Sprintf(`
 					resource "git_add" "test" {
 						directory  = "%s"
-						exact_path = "%s"
+						add_paths  = ["%s"]
 					}
 				`, directory, name2),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckResourceAttr("git_add.test", "exact_path", name2),
-					resource.TestCheckNoResourceAttr("git_add.test", "glob_path"),
-				),
-			},
-		},
-	})
-}
-
-func TestResourceGitAdd_GlobPath_Update(t *testing.T) {
-	t.Parallel()
-	directory, repository := testutils.CreateRepository(t)
-	defer os.RemoveAll(directory)
-	worktree := testutils.GetRepositoryWorktree(t, repository)
-	name1 := "some-file"
-	name2 := "other-file"
-	testutils.WriteFileInWorktree(t, worktree, name1)
-	testutils.WriteFileInWorktree(t, worktree, name2)
-
-	resource.UnitTest(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutils.ProviderFactories(),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-					resource "git_add" "test" {
-						directory  = "%s"
-						glob_path  = "some*"
-					}
-				`, directory),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckNoResourceAttr("git_add.test", "exact_path"),
-					resource.TestCheckResourceAttr("git_add.test", "glob_path", "some*"),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
-					resource "git_add" "test" {
-						directory  = "%s"
-						glob_path  = "other*"
-					}
-				`, directory),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("git_add.test", "directory", directory),
-					resource.TestCheckResourceAttr("git_add.test", "id", directory),
-					resource.TestCheckResourceAttr("git_add.test", "all", "true"),
-					resource.TestCheckNoResourceAttr("git_add.test", "exact_path"),
-					resource.TestCheckResourceAttr("git_add.test", "glob_path", "other*"),
+					resource.TestCheckResourceAttrWith("git_add.test", "id", testutils.CheckMinLength(1)),
+					resource.TestCheckResourceAttr("git_add.test", "add_paths.0", name2),
 				),
 			},
 		},

--- a/internal/provider/resource_git_tag.go
+++ b/internal/provider/resource_git_tag.go
@@ -204,7 +204,7 @@ func (r *resourceGitTag) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 }
 
-func (r *resourceGitTag) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *resourceGitTag) Update(ctx context.Context, _ resource.UpdateRequest, _ *resource.UpdateResponse) {
 	tflog.Debug(ctx, "Update git_tag")
 	// NO-OP: all attributes require replace, thus Delete and Create methods will be called
 }

--- a/internal/testutils/files.go
+++ b/internal/testutils/files.go
@@ -22,7 +22,11 @@ func TemporaryDirectory(t *testing.T) string {
 }
 
 func WriteFile(t *testing.T, name string) {
-	err := os.WriteFile(name, []byte("hello world!"), 0644)
+	WriteFileContent(t, name, "hello world!")
+}
+
+func WriteFileContent(t *testing.T, name string, content string) {
+	err := os.WriteFile(name, []byte(content), 0644)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testutils/repository.go
+++ b/internal/testutils/repository.go
@@ -43,8 +43,12 @@ func GetRepositoryHead(t *testing.T, repository *git.Repository) *plumbing.Refer
 }
 
 func WriteFileInWorktree(t *testing.T, worktree *git.Worktree, name string) {
-	filename := filepath.Join(worktree.Filesystem.Root(), name)
+	filename := FileInWorktree(worktree, name)
 	WriteFile(t, filename)
+}
+
+func FileInWorktree(worktree *git.Worktree, name string) string {
+	return filepath.Join(worktree.Filesystem.Root(), name)
 }
 
 func AddAndCommitNewFile(t *testing.T, worktree *git.Worktree, name string) {

--- a/project.mk
+++ b/project.mk
@@ -61,7 +61,7 @@ terratests: out/terratests-run-sentinel ## run all terratest tests
 
 .PHONY: terratest
 terratest: out/terratest-lock-sentinel ## run specific terratest tests
-	go test -timeout=120s -parallel=4 -tags testing -run $(filter-out $@,$(MAKECMDGOALS)) ./terratest/tests
+	go test -v -timeout=120s -parallel=4 -tags testing -run $(filter-out $@,$(MAKECMDGOALS)) ./terratest/tests
 
 .PHONY: tests
 tests: out/tests-sentinel ## run the unit tests

--- a/terratest/resources/git_add/multiple_files/main.tf
+++ b/terratest/resources/git_add/multiple_files/main.tf
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: The terraform-provider-git Authors
+# SPDX-License-Identifier: 0BSD
+
+terraform {
+  required_providers {
+    git = {
+      source  = "localhost/metio/git"
+      version = "9999.99.99"
+    }
+  }
+}
+
+provider "git" {
+  # Configuration options
+}
+
+resource "git_add" "add" {
+  directory = var.directory
+  add_paths = var.add_paths
+}
+
+data "git_statuses" "multiple_files" {
+  directory = git_add.add.directory
+}

--- a/terratest/resources/git_add/multiple_files/outputs.tf
+++ b/terratest/resources/git_add/multiple_files/outputs.tf
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The terraform-provider-git Authors
+# SPDX-License-Identifier: 0BSD
+
+output "directory" {
+  value = git_add.add.directory
+}
+
+output "id" {
+  value = git_add.add.id
+}
+
+output "add_paths" {
+  value = git_add.add.add_paths
+}
+
+output "files" {
+  value = data.git_statuses.multiple_files.files
+}

--- a/terratest/resources/git_add/multiple_files/variables.tf
+++ b/terratest/resources/git_add/multiple_files/variables.tf
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: The terraform-provider-git Authors
+# SPDX-License-Identifier: 0BSD
+
+variable "directory" {
+  type = string
+}
+
+variable "add_paths" {
+  type = list(string)
+}

--- a/terratest/resources/git_add/single_file/main.tf
+++ b/terratest/resources/git_add/single_file/main.tf
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: The terraform-provider-git Authors
+# SPDX-License-Identifier: 0BSD
+
+terraform {
+  required_providers {
+    git = {
+      source  = "localhost/metio/git"
+      version = "9999.99.99"
+    }
+  }
+}
+
+provider "git" {
+  # Configuration options
+}
+
+resource "git_add" "add" {
+  directory = var.directory
+  add_paths = var.add_paths
+}
+
+data "git_status" "single_file" {
+  directory = git_add.add.directory
+  file      = var.file
+}

--- a/terratest/resources/git_add/single_file/outputs.tf
+++ b/terratest/resources/git_add/single_file/outputs.tf
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: The terraform-provider-git Authors
+# SPDX-License-Identifier: 0BSD
+
+output "directory" {
+  value = git_add.add.directory
+}
+
+output "id" {
+  value = git_add.add.id
+}
+
+output "add_paths" {
+  value = git_add.add.add_paths
+}
+
+output "file" {
+  value = data.git_status.single_file.file
+}
+
+output "staging" {
+  value = data.git_status.single_file.staging
+}
+
+output "worktree" {
+  value = data.git_status.single_file.worktree
+}

--- a/terratest/resources/git_add/single_file/variables.tf
+++ b/terratest/resources/git_add/single_file/variables.tf
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: The terraform-provider-git Authors
+# SPDX-License-Identifier: 0BSD
+
+variable "directory" {
+  type = string
+}
+
+variable "add_paths" {
+  type = list(string)
+}
+
+variable "file" {
+  type = string
+}

--- a/terratest/tests/resource_git_add_test.go
+++ b/terratest/tests/resource_git_add_test.go
@@ -1,0 +1,374 @@
+/*
+ * SPDX-FileCopyrightText: The terraform-provider-git Authors
+ * SPDX-License-Identifier: 0BSD
+ */
+
+package provider_test
+
+import (
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/metio/terraform-provider-git/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestResourceGitAdd_SingleFile_Exact_WriteOnce(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{filename},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "A", actualStaging, "actualStaging")
+	assert.Equal(t, " ", actualWorktree, "actualWorktree")
+}
+
+func TestResourceGitAdd_SingleFile_Glob_WriteOnce(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{"some*"},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "A", actualStaging, "actualStaging")
+	assert.Equal(t, " ", actualWorktree, "actualWorktree")
+}
+
+func TestResourceGitAdd_SingleFile_Exact_NoMatch(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{"other-file"},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "?", actualStaging, "actualStaging")
+	assert.Equal(t, "?", actualWorktree, "actualWorktree")
+}
+
+func TestResourceGitAdd_SingleFile_Glob_NoMatch(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{"other*"},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "?", actualStaging, "actualStaging")
+	assert.Equal(t, "?", actualWorktree, "actualWorktree")
+}
+
+func TestResourceGitAdd_SingleFile_Exact_WriteMultiple(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{filename},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "A", actualStaging, "actualStaging")
+	assert.Equal(t, " ", actualWorktree, "actualWorktree")
+
+	// Modify file in order to trigger new git-add call
+	testutils.WriteFileContent(t, testutils.FileInWorktree(worktree, filename), "new content")
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging2 := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree2 := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "A", actualStaging2, "actualStaging2")
+	assert.Equal(t, " ", actualWorktree2, "actualWorktree2")
+}
+
+func TestResourceGitAdd_SingleFile_Glob_WriteMultiple(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{"some*"},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "A", actualStaging, "actualStaging")
+	assert.Equal(t, " ", actualWorktree, "actualWorktree")
+
+	// Modify file in order to trigger new git-add call
+	testutils.WriteFileContent(t, testutils.FileInWorktree(worktree, filename), "new content")
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging2 := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree2 := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "A", actualStaging2, "actualStaging2")
+	assert.Equal(t, " ", actualWorktree2, "actualWorktree2")
+}
+
+func TestResourceGitAdd_SingleFile_Exact_WriteDelete(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{filename},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "A", actualStaging, "actualStaging")
+	assert.Equal(t, " ", actualWorktree, "actualWorktree")
+
+	os.Remove(testutils.FileInWorktree(worktree, filename))
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging2 := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree2 := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "?", actualStaging2, "actualStaging2")
+	assert.Equal(t, "?", actualWorktree2, "actualWorktree2")
+}
+
+func TestResourceGitAdd_SingleFile_Glob_WriteDelete(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{"some*"},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "A", actualStaging, "actualStaging")
+	assert.Equal(t, " ", actualWorktree, "actualWorktree")
+
+	os.Remove(testutils.FileInWorktree(worktree, filename))
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging2 := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree2 := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "?", actualStaging2, "actualStaging2")
+	assert.Equal(t, "?", actualWorktree2, "actualWorktree2")
+}
+
+func TestResourceGitAdd_SingleFile_Exact_DeleteCommitted(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.AddAndCommitNewFile(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{filename},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "?", actualStaging, "actualStaging")
+	assert.Equal(t, "?", actualWorktree, "actualWorktree")
+
+	os.Remove(testutils.FileInWorktree(worktree, filename))
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging2 := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree2 := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "D", actualStaging2, "actualStaging2")
+	assert.Equal(t, " ", actualWorktree2, "actualWorktree2")
+}
+
+func TestResourceGitAdd_SingleFile_Glob_DeleteCommitted(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.AddAndCommitNewFile(t, worktree, filename)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/single_file",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{"some*"},
+			"file":      filename,
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "?", actualStaging, "actualStaging")
+	assert.Equal(t, "?", actualWorktree, "actualWorktree")
+
+	os.Remove(testutils.FileInWorktree(worktree, filename))
+	terraform.ApplyAndIdempotent(t, terraformOptions)
+
+	actualStaging2 := terraform.Output(t, terraformOptions, "staging")
+	actualWorktree2 := terraform.Output(t, terraformOptions, "worktree")
+
+	assert.Equal(t, "D", actualStaging2, "actualStaging2")
+	assert.Equal(t, " ", actualWorktree2, "actualWorktree2")
+}
+
+func TestResourceGitAdd_MultipleFiles_WriteOnce(t *testing.T) {
+	directory, repository := testutils.CreateRepository(t)
+	defer os.RemoveAll(directory)
+	worktree := testutils.GetRepositoryWorktree(t, repository)
+	filename := "some-file"
+	testutils.WriteFileInWorktree(t, worktree, filename)
+	testutils.WriteFileInWorktree(t, worktree, "other-file")
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../resources/git_add/multiple_files",
+		Vars: map[string]interface{}{
+			"directory": directory,
+			"add_paths": []string{filename},
+		},
+		NoColor: true,
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+	terraform.InitAndApplyAndIdempotent(t, terraformOptions)
+
+	actualFiles := terraform.OutputMapOfObjects(t, terraformOptions, "files")
+
+	assert.NotNil(t, actualFiles[filename], filename)
+	assert.NotNil(t, actualFiles["other-file"], filename)
+
+	stagedFile := actualFiles[filename].(map[string]interface{})
+	unStagedFile := actualFiles["other-file"].(map[string]interface{})
+
+	assert.Equal(t, "A", stagedFile["staging"], "stagedFile-staging")
+	assert.Equal(t, " ", stagedFile["worktree"], "stagedFile-worktree")
+	assert.Equal(t, "?", unStagedFile["staging"], "unStagedFile-staging")
+	assert.Equal(t, "?", unStagedFile["worktree"], "unStagedFile-worktree")
+}


### PR DESCRIPTION
This is a **breaking change**!

- The `all` attribute was removed entirely. The `git_add` resource now always adds files to the index even if those files are deleted.
- The `exact_path` and `glob_path` attributes were merged into `add_paths` which is a list of strings and accepts both exact paths to files/directories as well as glob patterns or a mixture of them.
- The `id` attribute now contains the unix nanoseconds of the last addition.

These changes were necessary because upstream go-git is buggy when it comes to adding 'all' files (see https://github.com/go-git/go-git/issues/223). The workaround implemented here uses `worktree.Add` instead of `worktree.AddWithOptions` which seems to work as expected. Acceptance tests with terratest were added that verify the wanted behavior.