### PR TITLE
fallback to default known_hosts file locations

### DIFF
--- a/internal/provider/git_push.go
+++ b/internal/provider/git_push.go
@@ -139,22 +139,21 @@ func CreatePushOptions(ctx context.Context, inputs *PushResourceModel, diag *dia
 }
 
 func knownHostsCallback(ctx context.Context, object types.Object, diag *diag.Diagnostics) ssh2.HostKeyCallback {
+	var hosts []string
 	knownHosts, ok := object.Attributes()["known_hosts"].(types.Set)
 	if ok && !knownHosts.IsNull() {
-		hosts := make([]string, len(knownHosts.Elements()))
 		diag.Append(knownHosts.ElementsAs(ctx, &hosts, false)...)
 		if diag.HasError() {
 			return nil
 		}
-		callback, err := knownhosts.New(hosts...)
-		if err != nil {
-			diag.AddError(
-				"Cannot use given known hosts",
-				"Known hosts configuration failed because of: "+err.Error(),
-			)
-			return nil
-		}
-		return callback
 	}
-	return nil
+	callback, err := knownhosts.New(hosts...)
+	if err != nil {
+		diag.AddError(
+			"Cannot use given known hosts",
+			"Known hosts configuration failed because of: "+err.Error(),
+		)
+		return nil
+	}
+	return callback
 }


### PR DESCRIPTION
We always have to call 'knownhosts.New' even if no known_hosts attribute was set by the user. The 'New' function will default to the default known_hosts file locations in case the supplied list of files is empty.